### PR TITLE
Updated handling of floating point types in get()

### DIFF
--- a/source/sqlite.d
+++ b/source/sqlite.d
@@ -91,8 +91,8 @@ class SQLite3
 				enforce!(db_exception)(typ == SQLITE3_TEXT,
 						"Column is not an string");
 				return to!string(sqlite3_column_text(stmt, pos));
-			} else static if(isFloat!T) {
-				enforce!(db_exception)(typ == SQLITE_REAL,
+			} else static if(isFloatingPoint!T) {
+				enforce!(db_exception)(typ == SQLITE_FLOAT,
 						"Column is not an real");
 				return sqlite3_column_double(stmt, pos);
 			} else {


### PR DESCRIPTION
I don't know if I am using a newer phobos version but I had to make these alterations to get sqlite.d working for floating point values.